### PR TITLE
Prevent submissions with package-lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c0d3",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Command Line Interface (CLI) for c0d3.com",
   "license": "MIT",
   "homepage": "https://c0d3.com",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,3 +16,6 @@ export const URL = 'https://www.c0d3.com/api/graphql'
 // Token from test account asynchronymouse
 export const DEBUG_TOKEN =
   'eyJpZCI6MTIxMCwiY2xpVG9rZW4iOiIxdHhrYndxMHYxa0hoenlHWmFmNTMifQ=='
+
+// Files that should make the submission invalid if present in diff
+export const DISALLOWED_FILES = ['package-lock.json', 'yarn.lock']

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -48,9 +48,13 @@ Please run ${bold.magenta(
 
 export const LOGOUT_ERROR = bold.red('The logout has failed.\n')
 
-export const DISALLOWED_FILES_COMMITTED = (files: string[]): string =>
-  bold.red(
+export const DISALLOWED_FILES_COMMITTED = (files: string[]): string => {
+  const singleFile = files.length > 1
+  return bold.red(
     `Your submission contains ${files.join(', ')}, ${
-      files.length > 1 ? 'these files are' : 'this file is'
-    } not meant to be submitted. Please remove them from your commit. Ask for help on C0D3 Discord if you are unsure how to fix this.`
+      singleFile ? 'these files are' : 'this file is'
+    } not meant to be submitted. Please remove ${
+      singleFile ? 'them' : 'it'
+    } from your commit. Ask for help on C0D3 Discord if you are unsure how to fix this.`
   )
+}

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -36,7 +36,7 @@ export const SUBMISSION_ERROR = bold.red(
 )
 
 export const SUBMISSION_SUCCEED = bold.green(
-  `Your submission was successfull!
+  `Your submission was successful!
   You will receive notification in chat when it is reviewed.
   Thank you!\n`
 )
@@ -47,3 +47,10 @@ Please run ${bold.magenta(
 )} to login first, then run ${bold.magenta('c0d3 submit')}.\n`
 
 export const LOGOUT_ERROR = bold.red('The logout has failed.\n')
+
+export const DISALLOWED_FILES_COMMITTED = (files: string[]): string =>
+  bold.red(
+    `Your submission contains ${files.join(', ')}, ${
+      files.length > 1 ? 'these files are' : 'this file is'
+    } not meant to be submitted. Please remove them from your commit. Ask for help on C0D3 Discord if you are unsure how to fix this.`
+  )

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -47,14 +47,3 @@ Please run ${bold.magenta(
 )} to login first, then run ${bold.magenta('c0d3 submit')}.\n`
 
 export const LOGOUT_ERROR = bold.red('The logout has failed.\n')
-
-export const DISALLOWED_FILES_COMMITTED = (files: string[]): string => {
-  const singleFile = files.length > 1
-  return bold.red(
-    `Your submission contains ${files.join(', ')}, ${
-      singleFile ? 'these files are' : 'this file is'
-    } not meant to be submitted. Please remove ${
-      singleFile ? 'them' : 'it'
-    } from your commit. Ask for help on C0D3 Discord if you are unsure how to fix this.`
-  )
-}

--- a/src/util/git.test.js
+++ b/src/util/git.test.js
@@ -2,7 +2,6 @@ import { getDiffAgainstMaster } from './git'
 import {
   WRONG_BRANCH,
   NO_DIFFERENCE,
-  DISALLOWED_FILES_COMMITTED,
 } from '../messages'
 
 jest.mock('simple-git/promise', () =>
@@ -12,8 +11,6 @@ jest.mock('simple-git/promise', () =>
         .fn()
         .mockResolvedValueOnce({ current: 'notMaster' })
         .mockResolvedValueOnce({ current: 'master' })
-        .mockResolvedValueOnce({ current: 'notMaster' })
-        .mockResolvedValueOnce({ current: 'notMaster' })
         .mockResolvedValueOnce({ current: 'notMaster' }),
 
       diff: jest
@@ -29,16 +26,8 @@ jest.mock('simple-git/promise', () =>
         // Stops at wrong branch error
         // Test 3
         // Called with --name-only flag
-        .mockResolvedValueOnce({ current: 'notMaster' })
+        .mockResolvedValueOnce(''),
         // no difference
-        // Test 4
-        // Called with --name-only flag
-        .mockResolvedValueOnce('package-lock.json\nindex.js')
-        // Disallowed files
-        // Test 5
-        // Called with --name-only flag
-        .mockResolvedValueOnce('package-lock.json\nyarn.lock'),
-        // Disallowed files
     }
   })
 )
@@ -46,7 +35,6 @@ jest.mock('simple-git/promise', () =>
 describe('getDiffAgainstMaster', () => {
   test('Should return diff', () => {
     expect(getDiffAgainstMaster()).resolves.toEqual({
-      changedFiles: ['index.js'],
       display: 'fakeDiff',
       db: 'fakeDiff',
     })
@@ -58,17 +46,5 @@ describe('getDiffAgainstMaster', () => {
 
   test('Should throw error: NO_DIFFERENCE', () => {
     expect(getDiffAgainstMaster()).rejects.toThrow(NO_DIFFERENCE)
-  })
-
-  test('Should throw error: (single) DISALLOWED_FILES_COMMITTED', () => {
-    expect(getDiffAgainstMaster()).rejects.toThrow(
-      DISALLOWED_FILES_COMMITTED(['package-lock.json'])
-    )
-  })
-
-  test('Should throw error: (multiple) DISALLOWED_FILES_COMMITTED', () => {
-    expect(getDiffAgainstMaster()).rejects.toThrow(
-      DISALLOWED_FILES_COMMITTED(['package-lock.json, yarn.lock'])
-    )
   })
 })

--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -1,24 +1,50 @@
-import gitP, { SimpleGit } from 'simple-git/promise'
-import { WRONG_BRANCH, CURRENT_BRANCH, NO_DIFFERENCE } from '../messages'
+import gitP from 'simple-git/promise'
+import { DISALLOWED_FILES } from '../constants'
+import {
+  CURRENT_BRANCH,
+  DISALLOWED_FILES_COMMITTED,
+  NO_DIFFERENCE,
+  WRONG_BRANCH,
+} from '../messages'
 
 type DiffObject = {
+  changedFiles: string[]
   db: string
   display: string
 }
 
-const git: SimpleGit = gitP()
+const git = gitP()
 
 export const getDiffAgainstMaster = async (): Promise<DiffObject> => {
   const { current } = await git.branch()
   if (current === 'master') throw new Error(WRONG_BRANCH)
   console.log(`${CURRENT_BRANCH} ${current}\n`)
 
-  const diff = {
-    display: await git.diff([`--color`, `master..${current}`]),
-    db: await git.diff([`master..${current}`]),
-  }
-  const hasDiffFromMaster = !!diff.db
+  const changedFilesString = await git.diff([
+    `master..${current}`,
+    '--name-only',
+  ])
+
+  const hasDiffFromMaster = !!changedFilesString.length
   if (!hasDiffFromMaster) throw new Error(NO_DIFFERENCE)
 
-  return diff
+  const changedFiles = changedFilesString.trim().split('\n')
+
+  const conflictingFiles = changedFiles.filter((file) =>
+    DISALLOWED_FILES.includes(file)
+  )
+
+  if (conflictingFiles.length)
+    throw new Error(DISALLOWED_FILES_COMMITTED(conflictingFiles))
+
+  const [display, db] = await Promise.all([
+    git.diff([`--color`, `master..${current}`]),
+    git.diff([`master..${current}`]),
+  ])
+
+  return {
+    changedFiles,
+    display,
+    db,
+  }
 }


### PR DESCRIPTION
Fixes #15

## Changes:
- ### src/constants.ts
  - Add an array of files which are not allowed in submissions
- ### ~~src/messages.ts~~
  - ~~Added error message generator for when disallowed files are present~~
  - Disallowed file are ignored silently.
- ### src/util/git.ts
  - ~~Check diff to see if any disallowed files are in commit, prevent submission if so.~~
  - Exclude disallowed files from diff.
- ### src/util/git.test.js
  - Updated tests.