### PR TITLE
Exclude files relative to root

### DIFF
--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -14,13 +14,14 @@ export const getDiffAgainstMaster = async (): Promise<DiffObject> => {
   if (current === 'master') throw new Error(WRONG_BRANCH)
   console.log(`${CURRENT_BRANCH} ${current}\n`)
 
-  const ignoreFileOptions = DISALLOWED_FILES.map((file) => `:!*${file}`)
+  // Files to exclude relative to git root
+  const ignoreFileOptions = DISALLOWED_FILES.map(
+    (file) => `:(exclude,top)${file}`
+  )
 
   const changedFilesString = await git.diff([
     `master..${current}`,
     '--name-only',
-    '--',
-    '.',
     ...ignoreFileOptions,
   ])
 
@@ -31,11 +32,9 @@ export const getDiffAgainstMaster = async (): Promise<DiffObject> => {
     git.diff([
       `--color`,
       `master..${current}`,
-      '--',
-      '.',
       ...ignoreFileOptions,
     ]),
-    git.diff([`master..${current}`, '--', '.', ...ignoreFileOptions]),
+    git.diff([`master..${current}`, ...ignoreFileOptions]),
   ])
 
   return {

--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -16,7 +16,7 @@ export const getDiffAgainstMaster = async (): Promise<DiffObject> => {
 
   // Files to exclude relative to git root
   const ignoreFileOptions = DISALLOWED_FILES.map(
-    (file) => `:(exclude,top)${file}`
+    (file) => `:(exclude,top)*${file}`
   )
 
   const changedFilesString = await git.diff([
@@ -29,11 +29,7 @@ export const getDiffAgainstMaster = async (): Promise<DiffObject> => {
   if (!hasDiffFromMaster) throw new Error(NO_DIFFERENCE)
 
   const [display, db] = await Promise.all([
-    git.diff([
-      `--color`,
-      `master..${current}`,
-      ...ignoreFileOptions,
-    ]),
+    git.diff([`--color`, `master..${current}`, ...ignoreFileOptions]),
     git.diff([`master..${current}`, ...ignoreFileOptions]),
   ])
 


### PR DESCRIPTION
Changes file path spec to exclude files relative to the repo root directory to make cli work regardless of the directory inside the repo. Fixes #23 

## Changes:
- ### src/util/git.ts
  - change excluded file args to `:(exclude,top)*${file}`