### PR TITLE
util/getToken: Update catch case to handle more errors with correct messages

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -23,6 +23,22 @@ export const WRONG_CREDENTIALS = bold.red(
   'Invalid credentials, please try again!\n'
 )
 
+export const UNREACHABLE_URL = bold.red(
+  'Server unreachable. Try again later.\n'
+)
+
+export const INVALID_URL = bold.red(
+  `Invalid URL. Only absolute URLs are supported (e.g, https://fakegraphql)`
+)
+
+export const UNSUPPORTED_GRAPHQL_REQUEST = bold.red(
+  'The provided GraphQL server cannot handle this request. Please check your server.'
+)
+
+export const UNHANDLED_ERROR = bold.red(
+  'Unhandled error. Please create an issue about it with a way to reproduce it in https://github.com/garageScript/c0d3-cli/issues'
+)
+
 export const SAVE_TOKEN_ERROR = bold.red(
   'Unable to create hidden directory and save credentials\n'
 )

--- a/src/util/credentials.test.js
+++ b/src/util/credentials.test.js
@@ -77,7 +77,7 @@ describe('getToken', () => {
 
   test('should throw error: WRONG_CREDENTIALS', () => {
     request.mockRejectedValue({
-        request: {
+        response: {
           status: 400
         }
     })
@@ -115,7 +115,7 @@ describe('getToken', () => {
 
   test('should throw error: UNSUPPORTED_GRAPHQL_REQUEST', () => {
     request.mockRejectedValue({
-        request: {
+      response: {
           status: 403
         }
     })

--- a/src/util/credentials.test.js
+++ b/src/util/credentials.test.js
@@ -1,5 +1,5 @@
 import fs, { promises as fsPromises } from 'fs'
-import { SAVE_TOKEN_ERROR, WRONG_CREDENTIALS, NOT_LOGGED_IN } from '../messages'
+import { SAVE_TOKEN_ERROR, WRONG_CREDENTIALS, NOT_LOGGED_IN, UNREACHABLE_URL, INVALID_URL, UNSUPPORTED_GRAPHQL_REQUEST, UNHANDLED_ERROR } from '../messages'
 import * as constants from '../constants'
 import { request } from 'graphql-request'
 import * as credentials from './credentials'
@@ -76,10 +76,59 @@ describe('getToken', () => {
   })
 
   test('should throw error: WRONG_CREDENTIALS', () => {
-    request.mockRejectedValue()
+    request.mockRejectedValue({
+        request: {
+          status: 400
+        }
+    })
     expect(
       credentials.getToken('fakeCredentials', 'fakeUrl')
     ).rejects.toThrowError(WRONG_CREDENTIALS)
+  })
+
+  test('should throw error: UNREACHABLE_URL', () => {
+    request.mockRejectedValue({
+        code: 'ENOTFOUND'
+    })
+    expect(
+      credentials.getToken('fakeCredentials', 'fakeUrl')
+    ).rejects.toThrowError(UNREACHABLE_URL)
+  })
+
+  test('should throw error: UNREACHABLE_URL', () => {
+    request.mockRejectedValue({
+        code: 'CERT_HAS_EXPIRED'
+    })
+    expect(
+      credentials.getToken('fakeCredentials', 'fakeUrl')
+    ).rejects.toThrowError(UNREACHABLE_URL)
+  })
+
+  test('should throw error: INVALID_URL', () => {
+    request.mockRejectedValue({
+        message: 'Only absolute URLs are supported'
+    })
+    expect(
+      credentials.getToken('fakeCredentials', 'fakeUrl')
+    ).rejects.toThrowError(INVALID_URL)
+  })
+
+  test('should throw error: UNSUPPORTED_GRAPHQL_REQUEST', () => {
+    request.mockRejectedValue({
+        request: {
+          status: 403
+        }
+    })
+    expect(
+      credentials.getToken('fakeCredentials', 'fakeUrl')
+    ).rejects.toThrowError(UNSUPPORTED_GRAPHQL_REQUEST)
+  })
+
+  test('should throw error: UNSUPPORTED_GRAPHQL_REQUEST', () => {
+    request.mockRejectedValue()
+    expect(
+      credentials.getToken('fakeCredentials', 'fakeUrl')
+    ).rejects.toThrowError(UNHANDLED_ERROR)
   })
 })
 

--- a/src/util/credentials.test.js
+++ b/src/util/credentials.test.js
@@ -124,7 +124,7 @@ describe('getToken', () => {
     ).rejects.toThrowError(UNSUPPORTED_GRAPHQL_REQUEST)
   })
 
-  test('should throw error: UNSUPPORTED_GRAPHQL_REQUEST', () => {
+  test('should throw error: UNHANDLED_ERROR', () => {
     request.mockRejectedValue()
     expect(
       credentials.getToken('fakeCredentials', 'fakeUrl')

--- a/src/util/credentials.ts
+++ b/src/util/credentials.ts
@@ -50,7 +50,10 @@ export const getToken: GetToken = async (credentials, url) => {
       throw new Error(UNSUPPORTED_GRAPHQL_REQUEST)
     }
 
-    // If the domain is not found or isn't
+    /* 
+    If the domain is not found or no 
+    graphql server to handle the request
+    */
     if (code && (code === 'ENOTFOUND' || code === 'CERT_HAS_EXPIRED')) {
       throw new Error(UNREACHABLE_URL)
     }

--- a/src/util/credentials.ts
+++ b/src/util/credentials.ts
@@ -38,7 +38,7 @@ export const getToken: GetToken = async (credentials, url) => {
     const { login } = await request<Token>(url, GET_CLI_TOKEN, credentials)
     return login.cliToken
   } catch (error) {
-    const status = error?.request?.status
+    const status = error?.response?.status
     const code = error?.code
     const message = error?.message
 

--- a/src/util/credentials.ts
+++ b/src/util/credentials.ts
@@ -11,7 +11,15 @@ import {
 } from '../@types/credentials'
 import { IS_TOKEN_VALID, GET_CLI_TOKEN } from '../graphql'
 import { CREDENTIALS_PATH, HIDDEN_DIR } from '../constants'
-import { WRONG_CREDENTIALS, SAVE_TOKEN_ERROR, NOT_LOGGED_IN, UNREACHABLE_URL, INVALID_URL, UNSUPPORTED_GRAPHQL_REQUEST, UNHANDLED_ERROR } from '../messages'
+import {
+  WRONG_CREDENTIALS,
+  SAVE_TOKEN_ERROR,
+  NOT_LOGGED_IN,
+  UNREACHABLE_URL,
+  INVALID_URL,
+  UNSUPPORTED_GRAPHQL_REQUEST,
+  UNHANDLED_ERROR,
+} from '../messages'
 
 export const getCredentials: VerifyToken = async (url) => {
   try {
@@ -42,11 +50,8 @@ export const getToken: GetToken = async (credentials, url) => {
       throw new Error(UNSUPPORTED_GRAPHQL_REQUEST)
     }
 
-    // If the domain is not found or isn't 
-    if (code && (
-      code === 'ENOTFOUND' || code === 'CERT_HAS_EXPIRED'
-    )
-    ) {
+    // If the domain is not found or isn't
+    if (code && (code === 'ENOTFOUND' || code === 'CERT_HAS_EXPIRED')) {
       throw new Error(UNREACHABLE_URL)
     }
 

--- a/src/util/credentials.ts
+++ b/src/util/credentials.ts
@@ -11,7 +11,7 @@ import {
 } from '../@types/credentials'
 import { IS_TOKEN_VALID, GET_CLI_TOKEN } from '../graphql'
 import { CREDENTIALS_PATH, HIDDEN_DIR } from '../constants'
-import { WRONG_CREDENTIALS, SAVE_TOKEN_ERROR, NOT_LOGGED_IN } from '../messages'
+import { WRONG_CREDENTIALS, SAVE_TOKEN_ERROR, NOT_LOGGED_IN, UNREACHABLE_URL, INVALID_URL, UNSUPPORTED_GRAPHQL_REQUEST, UNHANDLED_ERROR } from '../messages'
 
 export const getCredentials: VerifyToken = async (url) => {
   try {
@@ -30,7 +30,31 @@ export const getToken: GetToken = async (credentials, url) => {
     const { login } = await request<Token>(url, GET_CLI_TOKEN, credentials)
     return login.cliToken
   } catch (error) {
-    throw new Error(WRONG_CREDENTIALS)
+    const status = error?.request?.status
+    const code = error?.code
+    const message = error?.message
+
+    if (status && status === 400) {
+      throw new Error(WRONG_CREDENTIALS)
+    }
+
+    if (status && status !== 400) {
+      throw new Error(UNSUPPORTED_GRAPHQL_REQUEST)
+    }
+
+    // If the domain is not found or isn't 
+    if (code && (
+      code === 'ENOTFOUND' || code === 'CERT_HAS_EXPIRED'
+    )
+    ) {
+      throw new Error(UNREACHABLE_URL)
+    }
+
+    if (message && message === 'Only absolute URLs are supported') {
+      throw new Error(INVALID_URL)
+    }
+
+    throw new Error(UNHANDLED_ERROR)
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/garageScript/c0d3-cli/issues/28

This PR updates getToken catch to check the error message, code, or status to then send the right message accordingly. It also gets me familiar with the cli codebase to be able to tackle https://github.com/garageScript/c0d3-cli/issues/31