### PR TITLE
Send cliToken in Authorization header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c0d3",
-  "version": "2.1.4",
+  "version": "2.2.4",
   "description": "Command Line Interface (CLI) for c0d3.com",
   "license": "MIT",
   "homepage": "https://c0d3.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c0d3",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Command Line Interface (CLI) for c0d3.com",
   "license": "MIT",
   "homepage": "https://c0d3.com",

--- a/src/util/request.test.js
+++ b/src/util/request.test.js
@@ -1,4 +1,4 @@
-import request from 'graphql-request'
+import { GraphQLClient, request } from 'graphql-request'
 import { getLessons, sendSubmission } from './request'
 
 jest.mock('graphql-request')
@@ -17,7 +17,14 @@ describe('sendSubmission', () => {
   })
 
   test('Should throw error', () => {
-    request.mockRejectedValue()
+    GraphQLClient.mockImplementation(() => {
+      return {
+          request: () => {
+            throw new Error('hi')
+          }
+        }
+    });
+    
     expect(sendSubmission('fakeUrl', submission)).rejects.toThrowError()
   })
 })

--- a/src/util/request.ts
+++ b/src/util/request.ts
@@ -1,5 +1,5 @@
 import ora from 'ora'
-import request from 'graphql-request'
+import { request, GraphQLClient } from 'graphql-request'
 
 import { Lesson } from '../@types/prompt'
 import { GetLessons, SendSubmission } from '../@types/request'
@@ -29,8 +29,14 @@ export const sendSubmission: SendSubmission = async (
   submission
 ): Promise<void> => {
   try {
+    const graphQLClient = new GraphQLClient(url, {
+      headers: {
+        authorization: `Bearer ${submission.cliToken}`,
+      },
+    })
+
     spinner.start('Sending...')
-    await request(url, POST_SUBMISSION, submission)
+    await graphQLClient.request(POST_SUBMISSION, submission)
     spinner.succeed(SUBMISSION_SUCCEED)
   } catch (err) {
     console.log(err)


### PR DESCRIPTION
Related to https://github.com/garageScript/c0d3-app/issues/1551

This PR update `sendSubmission` code to send the `cliToken` in the Authorization header as Bearer token.

[Bump from 2.1.4 to 2.2.4](https://github.com/garageScript/c0d3-cli/pull/37/commits/87ce69aeff520f6e27f000c7466bb65888bb0583) was submitted by accident.