### PR TITLE
fix: getToken throw wrong error when user credentials are wrong

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c0d3",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Command Line Interface (CLI) for c0d3.com",
   "license": "MIT",
   "homepage": "https://c0d3.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c0d3",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Command Line Interface (CLI) for c0d3.com",
   "license": "MIT",
   "homepage": "https://c0d3.com",

--- a/src/util/credentials.test.js
+++ b/src/util/credentials.test.js
@@ -78,7 +78,7 @@ describe('getToken', () => {
   test('should throw error: WRONG_CREDENTIALS', () => {
     request.mockRejectedValue({
         response: {
-          status: 400
+          errors: [{ message: 'Password is invalid' }]
         }
     })
     expect(
@@ -86,7 +86,7 @@ describe('getToken', () => {
     ).rejects.toThrowError(WRONG_CREDENTIALS)
   })
 
-  test('should throw error: UNREACHABLE_URL', () => {
+  test('should throw error: UNREACHABLE_URL when code is ENOTFOUND', () => {
     request.mockRejectedValue({
         code: 'ENOTFOUND'
     })
@@ -95,7 +95,7 @@ describe('getToken', () => {
     ).rejects.toThrowError(UNREACHABLE_URL)
   })
 
-  test('should throw error: UNREACHABLE_URL', () => {
+  test('should throw error: UNREACHABLE_URL when code is CERT_HAS_EXPIRED', () => {
     request.mockRejectedValue({
         code: 'CERT_HAS_EXPIRED'
     })

--- a/src/util/credentials.ts
+++ b/src/util/credentials.ts
@@ -21,6 +21,56 @@ import {
   UNHANDLED_ERROR,
 } from '../messages'
 
+enum LoginErrors {
+  invalidPassword = 'Password is invalid',
+  userDoesNotExist = 'User does not exist',
+}
+
+enum URLErrors {
+  notAbsoluteURL = 'Only absolute URLs are supported',
+  httpURL = 'Only HTTP(S) protocols are supported',
+}
+
+export const handleGetTokenError = (error: {
+  response: { status: number; errors: { message: string }[] }
+  code: string
+  message: string
+}): never => {
+  const status = error?.response?.status
+  const code = error?.code
+  const message = error?.message
+  const graphqlMessage = error?.response?.errors?.[0].message
+
+  const isWrongCreds =
+    graphqlMessage === LoginErrors.invalidPassword ||
+    graphqlMessage === LoginErrors.userDoesNotExist
+
+  const isInvalidURL =
+    message === URLErrors.notAbsoluteURL || message === URLErrors.httpURL
+
+  if (isWrongCreds) {
+    throw new Error(WRONG_CREDENTIALS)
+  }
+
+  /* 
+    If the domain is not found or no 
+    graphql server to handle the request
+  */
+  if (code && (code === 'ENOTFOUND' || code === 'CERT_HAS_EXPIRED')) {
+    throw new Error(UNREACHABLE_URL)
+  }
+
+  if (isInvalidURL) {
+    throw new Error(INVALID_URL)
+  }
+
+  if (status && status !== 400) {
+    throw new Error(UNSUPPORTED_GRAPHQL_REQUEST)
+  }
+
+  throw new Error(UNHANDLED_ERROR)
+}
+
 export const getCredentials: VerifyToken = async (url) => {
   try {
     const { cliToken } = require(CREDENTIALS_PATH)
@@ -38,31 +88,7 @@ export const getToken: GetToken = async (credentials, url) => {
     const { login } = await request<Token>(url, GET_CLI_TOKEN, credentials)
     return login.cliToken
   } catch (error) {
-    const status = error?.response?.status
-    const code = error?.code
-    const message = error?.message
-
-    if (status && status === 400) {
-      throw new Error(WRONG_CREDENTIALS)
-    }
-
-    if (status && status !== 400) {
-      throw new Error(UNSUPPORTED_GRAPHQL_REQUEST)
-    }
-
-    /* 
-    If the domain is not found or no 
-    graphql server to handle the request
-    */
-    if (code && (code === 'ENOTFOUND' || code === 'CERT_HAS_EXPIRED')) {
-      throw new Error(UNREACHABLE_URL)
-    }
-
-    if (message && message === 'Only absolute URLs are supported') {
-      throw new Error(INVALID_URL)
-    }
-
-    throw new Error(UNHANDLED_ERROR)
+    return handleGetTokenError(error)
   }
 }
 


### PR DESCRIPTION
Closes #39 

This PR will:

- Refactor `getToken` function
- Extract GraphQL messages and throw errors based on them
- Remove the checking of the status code 400 because GraphQL always responds with 200