### PR TITLE
Send CLI version when the submission is sent

### DIFF
--- a/src/util/encoding.test.js
+++ b/src/util/encoding.test.js
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment node
+ */
+
+import { encode, decode } from './encoding'
+
+describe('Encoding and Decoding should work as expected', () => {
+    it('Encode encodes object into base64', () => {
+        expect.assertions(1)
+
+        const singleObj = {
+            token: 'abc',
+            userId: 1
+        }
+
+        const answer = Buffer.from(JSON.stringify(singleObj)).toString('base64')
+        expect(encode(singleObj)).toEqual(answer)
+    })
+    it('Decode extracts information from base64', () => {
+       expect.assertions(2)
+
+        const singleObj = {
+            token: 'abc',
+            userId: 1
+        }
+
+        const encStr = Buffer.from(JSON.stringify(singleObj)).toString('base64')
+        const { token, userId } = decode(encStr)
+        expect(token).toEqual('abc')
+        expect(userId).toEqual(1)
+    })
+})

--- a/src/util/encoding.ts
+++ b/src/util/encoding.ts
@@ -1,0 +1,13 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+export const encode = (payload: any): string => {
+  const payloadString = JSON.stringify(payload)
+  const encodedString = Buffer.from(payloadString).toString('base64')
+  return encodedString
+}
+
+export const decode = (payload: any): any => {
+  const buff = Buffer.from(payload, 'base64')
+  const decodedString = buff.toString('ascii')
+  return JSON.parse(decodedString)
+}

--- a/src/util/request.test.js
+++ b/src/util/request.test.js
@@ -1,4 +1,7 @@
+jest.mock('./encoding.ts')
+
 import { GraphQLClient, request } from 'graphql-request'
+import { decode, encode } from './encoding'
 import { getLessons, sendSubmission } from './request'
 
 jest.mock('graphql-request')
@@ -12,11 +15,20 @@ describe('sendSubmission', () => {
   }
 
   test('Should not throw error', async () => {
+    expect.assertions(1)
+
+    decode.mockReturnValue({
+      id: 1,
+      cliToken: submission.cliToken,
+    })
+
     const res = await sendSubmission('fakeUrl', submission)
     expect(res).toBe(undefined)
   })
 
   test('Should throw error', () => {
+    expect.assertions(1)
+
     GraphQLClient.mockImplementation(() => {
       return {
           request: () => {
@@ -27,16 +39,49 @@ describe('sendSubmission', () => {
     
     expect(sendSubmission('fakeUrl', submission)).rejects.toThrowError()
   })
+
+  test('Should set the authorization header as encoded cliToken and cliVersion', async () => {
+    expect.assertions(1)
+
+    GraphQLClient.mockImplementation(() => {
+      return {
+          request: () => {}
+        }
+    });
+
+    decode.mockReturnValue({
+      id: 1,
+      cliToken: submission.cliToken,
+    })
+
+    const encodedCliData = encode({
+      id: 1,
+      cliToken: submission.cliToken,
+      cliVersion: '2.1.5'
+    })
+
+    await sendSubmission('fakeUrl', submission)
+
+    expect(GraphQLClient).toBeCalledWith('fakeUrl', {
+      headers: {
+        authorization: `Bearer ${encodedCliData}`,
+      },
+    })
+  })
 })
 
 describe('getLessons', () => {
   test('Should not throw error', async () => {
+    expect.assertions(1)
+
     request.mockResolvedValue({lessons: ['lesson']})
     const res = await getLessons('fakeUrl')
     expect(res).toEqual(['lesson'])
   })
 
   test('Should throw error', () => {
+    expect.assertions(1)
+
     request.mockRejectedValue()
     expect(getLessons('fakeUrl')).rejects.toThrowError()
   })

--- a/src/util/request.ts
+++ b/src/util/request.ts
@@ -9,6 +9,8 @@ import {
   SUBMISSION_ERROR,
   SUBMISSION_SUCCEED,
 } from '../messages'
+import { decode, encode } from './encoding'
+const pkg = require('../../package.json')
 
 const spinner = ora()
 
@@ -29,9 +31,14 @@ export const sendSubmission: SendSubmission = async (
   submission
 ): Promise<void> => {
   try {
+    const encodedCliData = encode({
+      ...decode(submission.cliToken),
+      cliVersion: pkg.version,
+    })
+
     const graphQLClient = new GraphQLClient(url, {
       headers: {
-        authorization: `Bearer ${submission.cliToken}`,
+        authorization: `Bearer ${encodedCliData}`,
       },
     })
 


### PR DESCRIPTION
Related to https://github.com/garageScript/c0d3-app/issues/1552

This PR encodes the `cliVersion` and `cliToken` together and send them in the authorization header. It also create the [encoding.ts](https://github.com/garageScript/c0d3-app/blob/master/helpers/encoding.ts) file and its test.