### PR TITLE
feat(git): auto-detect checkout from non-master branch

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -14,6 +14,11 @@ export const WRONG_BRANCH = `Submissions must come from branches that are ${bold
 )}
 Please make sure that you branch, add, commit, and submit correctly.\n`
 
+export const NOT_MASTER = `Hey, You checked out from the wrong branch! You should checkout from master.\n
+ Here's a link to solve this problem: ${bold.magenta(
+   'https://github.com/garageScript/c0d3-cli/wiki/Students-issues#checked-out-from-a-branch-other-than-master'
+ )}\n`
+
 export const PROMPT_ORDER = bold.red(`The number needs to be a non-negative integer.
 To cancel submission, press Ctrl + d`)
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -19,6 +19,13 @@ export const NOT_MASTER = `Hey, You checked out from the wrong branch! You shoul
    'https://github.com/garageScript/c0d3-cli/wiki/Students-issues#checked-out-from-a-branch-other-than-master'
  )}\n`
 
+export const FAILED_GET_LASTCHECKOUT = `Failed to find if the branch was checked out from Master,
+please either create an issue on ${bold.magenta(
+  'https://github.com/garageScript/c0d3-cli/issues'
+)} or on our Discord server C0D3 on ${bold.magenta(
+  'https://discord.gg/MJ4PS4dK6J'
+)}\n`
+
 export const PROMPT_ORDER = bold.red(`The number needs to be a non-negative integer.
 To cancel submission, press Ctrl + d`)
 

--- a/src/util/git.test.js
+++ b/src/util/git.test.js
@@ -2,6 +2,8 @@ import { getDiffAgainstMaster } from './git'
 import {
   WRONG_BRANCH,
   NO_DIFFERENCE,
+  FAILED_GET_LASTCHECKOUT,
+  NOT_MASTER,
 } from '../messages'
 
 jest.mock('simple-git/promise', () =>
@@ -11,6 +13,8 @@ jest.mock('simple-git/promise', () =>
         .fn()
         .mockResolvedValueOnce({ current: 'notMaster' })
         .mockResolvedValueOnce({ current: 'master' })
+        .mockResolvedValueOnce({ current: 'notMaster' })
+        .mockResolvedValueOnce({ current: 'notMaster' })
         .mockResolvedValueOnce({ current: 'notMaster' }),
 
       diff: jest
@@ -26,25 +30,66 @@ jest.mock('simple-git/promise', () =>
         // Stops at wrong branch error
         // Test 3
         // Called with --name-only flag
-        .mockResolvedValueOnce(''),
+        .mockResolvedValueOnce('')
         // no difference
+        .mockResolvedValueOnce('fakeDiff')
+        .mockResolvedValueOnce('fakeDiff'),
+      
+
+      raw: jest
+        .fn()
+        .mockResolvedValueOnce(`
+        7abfefd HEAD@{0}: checkout: moving from master to branch2
+        7abfefd HEAD@{1}: checkout: moving from branch2 to master
+        `)
+        .mockResolvedValueOnce(`
+        7abfefd HEAD@{0}: checkout: moving from branch3 to branch2
+        7abfefd HEAD@{1}: checkout: moving from branch2 to master
+        `)
+        .mockResolvedValueOnce(``)
     }
   })
 )
 
 describe('getDiffAgainstMaster', () => {
   test('Should return diff', () => {
-    expect(getDiffAgainstMaster()).resolves.toEqual({
+    expect.assertions(1)
+    
+    return expect(getDiffAgainstMaster()).resolves.toEqual({
       display: 'fakeDiff',
       db: 'fakeDiff',
     })
   })
 
   test('Should throw error: WRONG_BRANCH', () => {
-    expect(getDiffAgainstMaster()).rejects.toThrow(WRONG_BRANCH)
+    expect.assertions(1)
+
+    return expect(getDiffAgainstMaster()).rejects.toThrow(WRONG_BRANCH)
   })
 
   test('Should throw error: NO_DIFFERENCE', () => {
-    expect(getDiffAgainstMaster()).rejects.toThrow(NO_DIFFERENCE)
+    expect.assertions(1)
+
+    return expect(getDiffAgainstMaster()).rejects.toThrow(NO_DIFFERENCE)
+  })
+
+  test('Should throw error: NOT_MASTER', () => {
+    expect.assertions(1)
+
+    return expect(getDiffAgainstMaster()).rejects.toThrow(NOT_MASTER)
+  })
+
+  test('Should log: FAILED_GET_LASTCHECKOUT', (done) => {
+    expect.assertions(1)
+
+    const consoleSpy = jest.spyOn(console, 'log');
+
+    // Assertions become 2 if used await
+    getDiffAgainstMaster().then(() => {
+      expect(consoleSpy).toHaveBeenNthCalledWith(2, FAILED_GET_LASTCHECKOUT)
+    
+      consoleSpy.mockClear()
+      done()
+    })
   })
 })


### PR DESCRIPTION
Resolve the first issue in #25 

This PR uses the output of `git reflog` to determine whether the user did checkout from master or not. 

The output of the command is something like this:

```
7abfefd HEAD@{0}: checkout: moving from master to branch2
7abfefd HEAD@{1}: checkout: moving from branch2 to master
```