### PR TITLE
feat: Stop sending `cliToken` in `sendSubmission` mutation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c0d3",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "Command Line Interface (CLI) for c0d3.com",
   "license": "MIT",
   "homepage": "https://c0d3.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c0d3",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "description": "Command Line Interface (CLI) for c0d3.com",
   "license": "MIT",
   "homepage": "https://c0d3.com",

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -28,7 +28,7 @@ export const POST_SUBMISSION = `
   mutation createSubmission(
     $lessonId: Int!
     $challengeId: Int!
-    $cliToken: String!
+    $cliToken: String
     $diff: String!
   ) {
     createSubmission(

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -28,13 +28,11 @@ export const POST_SUBMISSION = `
   mutation createSubmission(
     $lessonId: Int!
     $challengeId: Int!
-    $cliToken: String
     $diff: String!
   ) {
     createSubmission(
       lessonId: $lessonId
       challengeId: $challengeId
-      cliToken: $cliToken
       diff: $diff
     ) {
       id

--- a/src/util/request.ts
+++ b/src/util/request.ts
@@ -43,7 +43,16 @@ export const sendSubmission: SendSubmission = async (
     })
 
     spinner.start('Sending...')
-    await graphQLClient.request(POST_SUBMISSION, submission)
+
+    const { lessonId, challengeId, diff } = submission
+
+    const submissionWithoutCliToken = {
+      lessonId,
+      challengeId,
+      diff,
+    }
+
+    await graphQLClient.request(POST_SUBMISSION, submissionWithoutCliToken)
     spinner.succeed(SUBMISSION_SUCCEED)
   } catch (err) {
     console.log(err)


### PR DESCRIPTION
Closes https://github.com/garageScript/c0d3-cli/issues/38

Merging this PR will stop the `sendSubmission` mutation from sending the `cliToken`. When most of the users upgraded their CLI, its field type will be completely removed.