### PR TITLE
feat: Auto detect file issues before submitting

### DIFF
--- a/src/@types/prompt.d.ts
+++ b/src/@types/prompt.d.ts
@@ -26,6 +26,7 @@ export type AskForChallenges = (
 ) => Promise<{
   lessonId: number
   challengeId: number
+  lessonOrder: number
 }>
 
 export type AskForConfirmation = (message: string) => Promise<Question>

--- a/src/commands/submit.test.js
+++ b/src/commands/submit.test.js
@@ -40,6 +40,7 @@ describe('c0d3 submit', () => {
     askForChallenges.mockResolvedValue({
       lessonId: 666,
       challengeId: 666,
+      lessonOrder: 666,
     })
 
     askForConfirmation.mockResolvedValue({
@@ -62,6 +63,7 @@ describe('c0d3 submit', () => {
     askForChallenges.mockResolvedValue({
       lessonId: 666,
       challengeId: 666,
+      lessonOrder: 666,
     })
 
     askForConfirmation.mockResolvedValue({
@@ -82,6 +84,7 @@ describe('c0d3 submit', () => {
     askForChallenges.mockResolvedValue({
       lessonId: 666,
       challengeId: 666,
+      lessonOrder: 666,
     })
     expect(await submit(args)).toBe(undefined)
   })
@@ -115,6 +118,7 @@ describe('c0d3 submit', () => {
     askForChallenges.mockResolvedValue({
       lessonId: 666,
       challengeId: 666,
+      lessonOrder: 666,
     })
 
     askForConfirmation.mockResolvedValue({

--- a/src/commands/submit.ts
+++ b/src/commands/submit.ts
@@ -20,9 +20,9 @@ const submit = async ({
 }): Promise<void> => {
   try {
     const cliToken = debug ? DEBUG_TOKEN : await getCredentials(url)
-    const diff = await getDiffAgainstMaster()
     const lessons = await getLessons(url)
     const { lessonId, challengeId } = await askForChallenges(lessons)
+    const diff = await getDiffAgainstMaster(lessonId)
 
     displayBoxUI(DIFF_MSG + diff.display)
     const confirm = await askForConfirmation('The changes are correct?')

--- a/src/commands/submit.ts
+++ b/src/commands/submit.ts
@@ -21,8 +21,10 @@ const submit = async ({
   try {
     const cliToken = debug ? DEBUG_TOKEN : await getCredentials(url)
     const lessons = await getLessons(url)
-    const { lessonId, challengeId } = await askForChallenges(lessons)
-    const diff = await getDiffAgainstMaster(lessonId)
+    const { lessonId, challengeId, lessonOrder } = await askForChallenges(
+      lessons
+    )
+    const diff = await getDiffAgainstMaster(lessonOrder)
 
     displayBoxUI(DIFF_MSG + diff.display)
     const confirm = await askForConfirmation('The changes are correct?')

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -26,6 +26,23 @@ please either create an issue on ${bold.magenta(
   'https://discord.gg/MJ4PS4dK6J'
 )}\n`
 
+export const INVALID_CHALLENGE_FILE = bold.red(
+  'A valid challenge file could not be found. Make sure the file is not renamed and it has the following format: 1.js, 2.js, 3.js, ...etc\n'
+)
+
+export const SUBMITTING_PLUS_TWO_FILES = bold.red(`
+More than 2 files are being submitted. Please make sure there is no branching issues. 
+
+${bold.cyan('If there is, you can solve it by following the links below:')}
+${bold.magenta(`
+- https://www.c0d3.com/docs/setup#reusing-your-branches
+- https://github.com/garageScript/c0d3-cli/wiki/Students-issues#checked-out-from-a-branch-other-than-master`)}
+
+${bold.magenta(
+  `If the links above didn't help, please reach on Discord (https://discord.gg/MJ4PS4dK6J)!`
+)}
+`)
+
 export const PROMPT_ORDER = bold.red(`The number needs to be a non-negative integer.
 To cancel submission, press Ctrl + d`)
 

--- a/src/util/dynamicMessages.test.js
+++ b/src/util/dynamicMessages.test.js
@@ -1,0 +1,16 @@
+const { INVALID_SECOND_FILE } = require("./dynamicMessages");
+import { bold } from 'chalk'
+
+describe('Dynamic messages', () => {
+    it('Should add string to INVALID_SECOND_FILE', () => {
+        expect(INVALID_SECOND_FILE('abc.js')).toEqual(
+            bold.red("Invalid second file (abc.js) to be submitted. Please make sure you are submitting a valid test file (abc.test.js) if it is supposed to be a test file, else remove it and submit")
+        )
+    })
+
+    it('Should remove parent dir and add string to INVALID_SECOND_FILE', () => {
+        expect(INVALID_SECOND_FILE('abc')).toEqual(
+            bold.red("Invalid second file (abc) to be submitted. Please make sure you are submitting a valid test file (abc.test.js) if it is supposed to be a test file, else remove it and submit")
+        )
+    })
+})

--- a/src/util/dynamicMessages.ts
+++ b/src/util/dynamicMessages.ts
@@ -1,0 +1,13 @@
+import { bold } from 'chalk'
+
+export const INVALID_SECOND_FILE = (invalidFile?: string): string =>
+  bold.red(
+    `Invalid second file ${
+      invalidFile && `(${invalidFile})`
+    } to be submitted. Please make sure you are submitting a valid test file ${
+      invalidFile &&
+      `(${
+        invalidFile.includes('.') ? invalidFile.split('.')[0] : invalidFile
+      }.test.js)`
+    } if it is supposed to be a test file, else remove it and submit`
+  )

--- a/src/util/git.test.js
+++ b/src/util/git.test.js
@@ -4,7 +4,10 @@ import {
   NO_DIFFERENCE,
   FAILED_GET_LASTCHECKOUT,
   NOT_MASTER,
+  INVALID_CHALLENGE_FILE,
+  SUBMITTING_PLUS_TWO_FILES,
 } from '../messages'
+import { INVALID_SECOND_FILE } from './dynamicMessages'
 
 jest.mock('simple-git/promise', () =>
   jest.fn(() => {
@@ -15,26 +18,55 @@ jest.mock('simple-git/promise', () =>
         .mockResolvedValueOnce({ current: 'master' })
         .mockResolvedValueOnce({ current: 'notMaster' })
         .mockResolvedValueOnce({ current: 'notMaster' })
+        .mockResolvedValueOnce({ current: 'notMaster' })
+        .mockResolvedValueOnce({ current: 'notMaster' })
+        .mockResolvedValueOnce({ current: 'notMaster' })
+        .mockResolvedValueOnce({ current: 'notMaster' })
+        .mockResolvedValueOnce({ current: 'notMaster' })
+        .mockResolvedValueOnce({ current: 'notMaster' })
+        .mockResolvedValueOnce({ current: 'notMaster' })
         .mockResolvedValueOnce({ current: 'notMaster' }),
 
       diff: jest
         .fn()
         // Test 1
         // Called with --name-only flag
-        .mockResolvedValueOnce('index.js')
+        .mockResolvedValueOnce('\njs0/1.js')
         // Db Diff
-        .mockResolvedValueOnce('fakeDiff')
+        .mockResolvedValueOnce('\njs0/1.js')
         // Display Diff
-        .mockResolvedValueOnce('fakeDiff')
+        .mockResolvedValueOnce('\njs0/1.js')
         // Test 2
         // Stops at wrong branch error
         // Test 3
         // Called with --name-only flag
         .mockResolvedValueOnce('')
         // no difference
-        .mockResolvedValueOnce('fakeDiff')
-        .mockResolvedValueOnce('fakeDiff'),
-      
+        .mockResolvedValueOnce('\njs0/1.js')
+        .mockResolvedValueOnce('\njs0/1.js')
+        // FAILED_TO_GET_LASTCHECKOUT
+        .mockResolvedValueOnce('\njs0/abc.js')
+        .mockResolvedValueOnce('\njs0/abc.js')
+        .mockResolvedValueOnce('\njs0/abc.js')
+        // INVALID_CHALLENGE_FILE
+        .mockResolvedValueOnce('\njs0/1.js')
+        .mockResolvedValueOnce('\njs0/1.js')
+        .mockResolvedValueOnce('\njs0/1.js')
+        // Should not throw INVALID_CHALLENGE_FILE
+        .mockResolvedValueOnce('\njs0/1.js \njs0/2.js \njs0/3.js')
+        // SUBMITTING_PLUS_TWO_FILES
+        .mockResolvedValueOnce('\njs0/abc.js \njs0/1.test.js')
+        // INVALID_CHALLENGE_FILE for no challenge files
+        .mockResolvedValueOnce('\njs0/1.js \njs0/2.js')
+        // SUBMITTING_PLUS_TWO_FILES for submitting +2 challenges
+        .mockResolvedValueOnce('\njs0/1.js \nabc.js')
+        // INVALID_SECOND_FILE
+        .mockResolvedValueOnce('\njs0/1.js \njs0/1.test.js')
+        .mockResolvedValueOnce('\njs0/1.js \njs0/1.test.js')
+        .mockResolvedValueOnce('\njs0/1.js \njs0/1.test.js'),
+        // Should submit with test file
+
+
 
       raw: jest
         .fn()
@@ -47,6 +79,13 @@ jest.mock('simple-git/promise', () =>
         7abfefd HEAD@{1}: checkout: moving from branch2 to master
         `)
         .mockResolvedValueOnce(``)
+        .mockResolvedValueOnce(``)
+        .mockResolvedValueOnce(``)
+        .mockResolvedValueOnce(``)
+        .mockResolvedValueOnce(``)
+        .mockResolvedValueOnce(``)
+        .mockResolvedValueOnce(``)
+        .mockResolvedValueOnce(``)
     }
   })
 )
@@ -54,29 +93,29 @@ jest.mock('simple-git/promise', () =>
 describe('getDiffAgainstMaster', () => {
   test('Should return diff', () => {
     expect.assertions(1)
-    
-    return expect(getDiffAgainstMaster()).resolves.toEqual({
-      display: 'fakeDiff',
-      db: 'fakeDiff',
+
+    return expect(getDiffAgainstMaster(5)).resolves.toEqual({
+      display: '\njs0/1.js',
+      db: '\njs0/1.js',
     })
   })
 
   test('Should throw error: WRONG_BRANCH', () => {
     expect.assertions(1)
 
-    return expect(getDiffAgainstMaster()).rejects.toThrow(WRONG_BRANCH)
+    return expect(getDiffAgainstMaster(5)).rejects.toThrow(WRONG_BRANCH)
   })
 
   test('Should throw error: NO_DIFFERENCE', () => {
     expect.assertions(1)
 
-    return expect(getDiffAgainstMaster()).rejects.toThrow(NO_DIFFERENCE)
+    return expect(getDiffAgainstMaster(5)).rejects.toThrow(NO_DIFFERENCE)
   })
 
   test('Should throw error: NOT_MASTER', () => {
     expect.assertions(1)
 
-    return expect(getDiffAgainstMaster()).rejects.toThrow(NOT_MASTER)
+    return expect(getDiffAgainstMaster(5)).rejects.toThrow(NOT_MASTER)
   })
 
   test('Should log: FAILED_GET_LASTCHECKOUT', (done) => {
@@ -85,11 +124,59 @@ describe('getDiffAgainstMaster', () => {
     const consoleSpy = jest.spyOn(console, 'log');
 
     // Assertions become 2 if used await
-    getDiffAgainstMaster().then(() => {
+    getDiffAgainstMaster(5).then(() => {
       expect(consoleSpy).toHaveBeenNthCalledWith(2, FAILED_GET_LASTCHECKOUT)
-    
+
       consoleSpy.mockClear()
       done()
+    })
+  })
+
+  test('Should throw error: INVALID_CHALLENGE_FILE', () => {
+    expect.assertions(1)
+
+    return expect(getDiffAgainstMaster(2)).rejects.toThrow(INVALID_CHALLENGE_FILE)
+  })
+  
+  test('Should not throw error: INVALID_CHALLENGE_FILE', () => {
+    expect.assertions(1)
+
+    return expect(getDiffAgainstMaster(2)).resolves.not.toThrow(INVALID_CHALLENGE_FILE)
+  })
+
+  test('Should throw error: SUBMITTING_PLUS_TWO_FILES', () => {
+    expect.assertions(1)
+
+    return expect(getDiffAgainstMaster(2)).rejects.toThrow(SUBMITTING_PLUS_TWO_FILES)
+  })
+
+  test('Should throw error: INVALID_CHALLENGE_FILE for no challenge files', () => {
+    expect.assertions(1)
+
+    return expect(getDiffAgainstMaster(2)).rejects.toThrow(INVALID_CHALLENGE_FILE)
+  })
+
+  test('Should throw error: SUBMITTING_PLUS_TWO_FILES for submitting +2 challenges', () => {
+    expect.assertions(1)
+
+    return expect(getDiffAgainstMaster(2)).rejects.toThrow(SUBMITTING_PLUS_TWO_FILES)
+  })
+
+  test('Should throw error: INVALID_SECOND_FILE', () => {
+    expect.assertions(1)
+
+    // handles when e.includes('/) is false
+    const error = INVALID_SECOND_FILE('abc.js')
+
+    return expect(getDiffAgainstMaster(2)).rejects.toThrow(error)
+  })
+
+  test('Should submit with test file', () => {
+    expect.assertions(1)
+
+    return expect(getDiffAgainstMaster(2)).resolves.toStrictEqual({
+      db: "\njs0/1.js \njs0/1.test.js",
+      display: "\njs0/1.js \njs0/1.test.js",
     })
   })
 })

--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -37,9 +37,11 @@ const didCheckoutFromMaster = async () => {
   return splitLastCheckoutMove[0].trim() === 'master'
 }
 
-const validateFiles = (changedFilesString: string, lessonId: number) => {
-  // 4 is js3 or Objects
-  if (lessonId > 4) return
+const validateFiles = (changedFilesString: string, lessonOrder: number) => {
+  // 3 is js3 or Objects
+  if (lessonOrder > 3) return
+
+  const fileNameRegex = /(^\d+).js/g // Matches 1.js 2.js 3.js ...etc
 
   const predictValidFile = (e: string) =>
     e.includes('/')
@@ -47,7 +49,6 @@ const validateFiles = (changedFilesString: string, lessonId: number) => {
       : e.match(fileNameRegex)
 
   const changedFilesArray = changedFilesString.trim().split('\n')
-  const fileNameRegex = /(^\d+).js/g // Matches 1.js 2.js 3.js ...etc
 
   // If a single file - [1.js]
   if (changedFilesArray.length === 1 && changedFilesArray[0]) {
@@ -84,7 +85,7 @@ const validateFiles = (changedFilesString: string, lessonId: number) => {
 }
 
 export const getDiffAgainstMaster = async (
-  lessonId: number
+  lessonOrder: number
 ): Promise<DiffObject> => {
   const { current } = await git.branch()
   if (current === 'master') throw new Error(WRONG_BRANCH)
@@ -108,7 +109,7 @@ export const getDiffAgainstMaster = async (
   if (typeof isMasterBranch === 'string') console.log(isMasterBranch)
   if (!isMasterBranch) throw new Error(NOT_MASTER)
 
-  validateFiles(changedFilesString, lessonId)
+  validateFiles(changedFilesString, lessonOrder)
 
   const [display, db] = await Promise.all([
     git.diff([`--color`, `master..${current}`, ...ignoreFileOptions]),

--- a/src/util/prompt.test.js
+++ b/src/util/prompt.test.js
@@ -97,9 +97,11 @@ describe('askForChallenges', () => {
       .fn()
       .mockResolvedValueOnce({ lessonOrder: '0' })
       .mockResolvedValueOnce({ challengeOrder: '10' })
+      .mockResolvedValueOnce({ lessonOrder: '10' })
     expect(askForChallenges(lessons)).resolves.toEqual({
       challengeId: 104,
-      lessonId: 5
+      lessonId: 5,
+      lessonOrder: '0'
     })
   })
 
@@ -108,6 +110,7 @@ describe('askForChallenges', () => {
       .fn()
       .mockResolvedValueOnce({ lessonOrder: '0' })
       .mockResolvedValueOnce({ challengeOrder: '10' })
+      .mockResolvedValueOnce({ lessonOrder: '10' })
     await askForChallenges(lessons)
     const invalidLesson = enquirer.prompt.mock.calls[0][0][0].validate(
       'wrongInput'
@@ -117,11 +120,13 @@ describe('askForChallenges', () => {
       'wrongInput'
     )
     const validChallenge = enquirer.prompt.mock.calls[1][0][0].validate(10)
+    const validLessonOrder = enquirer.prompt.mock.calls[1][0][0].validate('10')
 
     expect(invalidLesson).toBe(PROMPT_ORDER)
     expect(validLesson).toBe(true)
     expect(invalidChallenge).toBe(PROMPT_ORDER)
     expect(validChallenge).toBe(true)
+    expect(validLessonOrder).toBe(true)
   })
 })
 

--- a/src/util/prompt.ts
+++ b/src/util/prompt.ts
@@ -80,6 +80,7 @@ export const askForChallenges: AskForChallenges = async (lessons) => {
   return {
     lessonId: Number(lessonsByOrder[lessonOrder].id),
     challengeId: Number(challengeByOrder[challengeOrder].id),
+    lessonOrder,
   }
 }
 


### PR DESCRIPTION
Related to https://github.com/garageScript/c0d3-cli/issues/25

This PR adds some checks to validate the files. These checks will check if the student is:

---

_Invalid file: `abc.js` or `abc.test.js`_
_Valid file: `1.js` or `1.test.js`_

---

1. Submitting more than 2 files
2. Submitting 1 challenge file and 1 invalid file such as `abc.js`
3. Submitting no valid challenge files
4. Submitting 1 challenge file and the second file isn't a test file
5. Submitting 1 challenge file and is valid

I need suggestions to improve the error messages.