### PR TITLE
feat(git): Verify the challenge to be submitted

### DIFF
--- a/src/@types/prompt.d.ts
+++ b/src/@types/prompt.d.ts
@@ -27,6 +27,7 @@ export type AskForChallenges = (
   lessonId: number
   challengeId: number
   lessonOrder: number
+  challengeOrder: number
 }>
 
 export type AskForConfirmation = (message: string) => Promise<Question>

--- a/src/commands/submit.ts
+++ b/src/commands/submit.ts
@@ -21,10 +21,13 @@ const submit = async ({
   try {
     const cliToken = debug ? DEBUG_TOKEN : await getCredentials(url)
     const lessons = await getLessons(url)
-    const { lessonId, challengeId, lessonOrder } = await askForChallenges(
-      lessons
-    )
-    const diff = await getDiffAgainstMaster(lessonOrder)
+    const {
+      lessonId,
+      challengeId,
+      lessonOrder,
+      challengeOrder,
+    } = await askForChallenges(lessons)
+    const diff = await getDiffAgainstMaster(lessonOrder, challengeOrder)
 
     displayBoxUI(DIFF_MSG + diff.display)
     const confirm = await askForConfirmation('The changes are correct?')

--- a/src/util/dynamicMessages.ts
+++ b/src/util/dynamicMessages.ts
@@ -11,3 +11,18 @@ export const INVALID_SECOND_FILE = (invalidFile?: string): string =>
       }.test.js)`
     } if it is supposed to be a test file, else remove it and submit`
   )
+
+export const WRONG_CHALLENGE_TO_SUBMIT = (
+  selectedChallengeOrder?: string,
+  modifiedChallengeOrder?: string
+): string =>
+  bold.red(
+    `
+The challenge you selected (${selectedChallengeOrder}) to be submitted is not the same as the modified challenge file (${modifiedChallengeOrder}.js)\n
+${bold.blue(
+  `Please either reset the last commit with ${bold.magentaBright(
+    'git reset --soft HEAD~'
+  )} and modify the correct challenge (${selectedChallengeOrder}.js) or select the modified challenge (${modifiedChallengeOrder})`
+)}
+`
+  )

--- a/src/util/prompt.test.js
+++ b/src/util/prompt.test.js
@@ -101,7 +101,8 @@ describe('askForChallenges', () => {
     expect(askForChallenges(lessons)).resolves.toEqual({
       challengeId: 104,
       lessonId: 5,
-      lessonOrder: '0'
+      lessonOrder: '0',
+      challengeOrder: "10"
     })
   })
 

--- a/src/util/prompt.ts
+++ b/src/util/prompt.ts
@@ -81,6 +81,7 @@ export const askForChallenges: AskForChallenges = async (lessons) => {
     lessonId: Number(lessonsByOrder[lessonOrder].id),
     challengeId: Number(challengeByOrder[challengeOrder].id),
     lessonOrder,
+    challengeOrder,
   }
 }
 


### PR DESCRIPTION
Closes #54 

# Problem

Currently, the user can add/commit a file named `1.js`, select to submit for the 3rd challenge, and it'll be submitted. The selected challenge to submit should be the same as the modified challenge file. If the file is `1.js`, the user must select challenge 1 to submit to.

# Solution

Check if the selected challenge is the same as the modified challenge file by comparing the selected challenge order and the challenge file name.  The filename `<challengeOrder>.js` corresponds to the challenge-to-submit-to order.

Cases:
- If they modified the file `3.js`, they must choose the 3rd challenge to submit to: ✅ 
- If they modified the file `3.js` and try to submit to the first challenge, it'll throw an error: ⚠️ 

### Issue

It should also check if the user is submitting the challenge to the correct lesson. If the modified file is `js0/1.js` and the user tries to submit to `js1` or `Variables & Functions`, it should throw an error as `js0` and `js1` are different.