### PR TITLE
fix: Unable to submit an HTML file to JS3

### DIFF
--- a/src/@types/prompt.d.ts
+++ b/src/@types/prompt.d.ts
@@ -26,7 +26,7 @@ export type AskForChallenges = (
 ) => Promise<{
   lessonId: number
   challengeId: number
-  lessonOrder: number
+  lessonOrder: string
   challengeOrder: number
 }>
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -27,7 +27,7 @@ please either create an issue on ${bold.magenta(
 )}\n`
 
 export const INVALID_CHALLENGE_FILE = bold.red(
-  'A valid challenge file could not be found. Make sure the file is not renamed and it has the following format: 1.js, 2.js, 3.js, ...etc\n'
+  'A valid challenge file could not be found. Make sure the file is not renamed and it has the following format: 1.js, 2.js, 3.js, 10.html (only for JS3 challenge 10) ...etc\n'
 )
 
 export const PROMPT_ORDER = bold.red(`The number needs to be a non-negative integer.

--- a/src/util/dynamicMessages.test.js
+++ b/src/util/dynamicMessages.test.js
@@ -4,13 +4,13 @@ import { bold } from 'chalk'
 describe('Dynamic messages', () => {
     it('Should add string to INVALID_SECOND_FILE', () => {
         expect(INVALID_SECOND_FILE('abc.js')).toEqual(
-            bold.red("Invalid second file (abc.js) to be submitted. Please make sure you are submitting a valid test file (abc.test.js) if it is supposed to be a test file, else remove it and submit")
+            bold.red("Invalid second file (abc.js) to be submitted. Please make sure you are submitting a valid test file (abc.test.js) if it is supposed to be a test file.\nIf it's supposed to be the HTML script file, please include it in the HTML file.")
         )
     })
 
     it('Should remove parent dir and add string to INVALID_SECOND_FILE', () => {
         expect(INVALID_SECOND_FILE('abc')).toEqual(
-            bold.red("Invalid second file (abc) to be submitted. Please make sure you are submitting a valid test file (abc.test.js) if it is supposed to be a test file, else remove it and submit")
+            bold.red("Invalid second file (abc) to be submitted. Please make sure you are submitting a valid test file (abc.test.js) if it is supposed to be a test file.\nIf it's supposed to be the HTML script file, please include it in the HTML file.")
         )
     })
 })

--- a/src/util/dynamicMessages.ts
+++ b/src/util/dynamicMessages.ts
@@ -9,7 +9,10 @@ export const INVALID_SECOND_FILE = (invalidFile?: string): string =>
       `(${
         invalidFile.includes('.') ? invalidFile.split('.')[0] : invalidFile
       }.test.js)`
-    } if it is supposed to be a test file, else remove it and submit`
+    } if it is supposed to be a test file.
+
+    If it's supposed to be the HTML script file, please include it in the HTML file.
+    `
   )
 
 export const WRONG_CHALLENGE_TO_SUBMIT = (

--- a/src/util/dynamicMessages.ts
+++ b/src/util/dynamicMessages.ts
@@ -9,10 +9,7 @@ export const INVALID_SECOND_FILE = (invalidFile?: string): string =>
       `(${
         invalidFile.includes('.') ? invalidFile.split('.')[0] : invalidFile
       }.test.js)`
-    } if it is supposed to be a test file.
-
-    If it's supposed to be the HTML script file, please include it in the HTML file.
-    `
+    } if it is supposed to be a test file.\nIf it's supposed to be the HTML script file, please include it in the HTML file.`
   )
 
 export const WRONG_CHALLENGE_TO_SUBMIT = (

--- a/src/util/git.test.js
+++ b/src/util/git.test.js
@@ -77,7 +77,7 @@ jest.mock('simple-git/promise', () =>
         .mockResolvedValueOnce('\njs3/1.html')
         .mockResolvedValueOnce('\njs3/1.html')
         .mockResolvedValueOnce('\njs3/1.html')
-        // Should not submit if invalid html file
+        // Should continue if not valid html file
         .mockResolvedValueOnce('\njs3/1.mdx')
         .mockResolvedValueOnce('\njs3/1.mdx')
         .mockResolvedValueOnce('\njs3/1.mdx'),

--- a/src/util/git.test.js
+++ b/src/util/git.test.js
@@ -7,7 +7,10 @@ import {
   INVALID_CHALLENGE_FILE,
   SUBMITTING_PLUS_TWO_FILES,
 } from '../messages'
-import { INVALID_SECOND_FILE, WRONG_CHALLENGE_TO_SUBMIT } from './dynamicMessages'
+import {
+  INVALID_SECOND_FILE,
+  WRONG_CHALLENGE_TO_SUBMIT,
+} from './dynamicMessages'
 
 jest.mock('simple-git/promise', () =>
   jest.fn(() => {
@@ -16,6 +19,7 @@ jest.mock('simple-git/promise', () =>
         .fn()
         .mockResolvedValueOnce({ current: 'notMaster' })
         .mockResolvedValueOnce({ current: 'master' })
+        .mockResolvedValueOnce({ current: 'notMaster' })
         .mockResolvedValueOnce({ current: 'notMaster' })
         .mockResolvedValueOnce({ current: 'notMaster' })
         .mockResolvedValueOnce({ current: 'notMaster' })
@@ -68,18 +72,30 @@ jest.mock('simple-git/promise', () =>
         // Should not throw error: INVALID_CHALLENGE_FILE on wrong file
         .mockResolvedValueOnce('\njs0/1.js')
         .mockResolvedValueOnce('\njs0/1.js')
-        .mockResolvedValueOnce('\njs0/1.js'),
+        .mockResolvedValueOnce('\njs0/1.js')
+        // Should submit if html file and lesson is JS3
+        .mockResolvedValueOnce('\njs3/1.html')
+        .mockResolvedValueOnce('\njs3/1.html')
+        .mockResolvedValueOnce('\njs3/1.html')
+        // Should not submit if invalid html file
+        .mockResolvedValueOnce('\njs3/1.mdx')
+        .mockResolvedValueOnce('\njs3/1.mdx')
+        .mockResolvedValueOnce('\njs3/1.mdx'),
 
       raw: jest
         .fn()
-        .mockResolvedValueOnce(`
+        .mockResolvedValueOnce(
+          `
         7abfefd HEAD@{0}: checkout: moving from master to branch2
         7abfefd HEAD@{1}: checkout: moving from branch2 to master
-        `)
-        .mockResolvedValueOnce(`
+        `
+        )
+        .mockResolvedValueOnce(
+          `
         7abfefd HEAD@{0}: checkout: moving from branch3 to branch2
         7abfefd HEAD@{1}: checkout: moving from branch2 to master
-        `)
+        `
+        )
         .mockResolvedValueOnce(``)
         .mockResolvedValueOnce(``)
         .mockResolvedValueOnce(``)
@@ -90,6 +106,8 @@ jest.mock('simple-git/promise', () =>
         .mockResolvedValueOnce(``)
         .mockResolvedValueOnce(``)
         .mockResolvedValueOnce(``)
+        .mockResolvedValueOnce(``)
+        .mockResolvedValueOnce(``),
     }
   })
 )
@@ -125,7 +143,7 @@ describe('getDiffAgainstMaster', () => {
   test('Should log: FAILED_GET_LASTCHECKOUT', (done) => {
     expect.assertions(1)
 
-    const consoleSpy = jest.spyOn(console, 'log');
+    const consoleSpy = jest.spyOn(console, 'log')
 
     // Assertions become 2 if used await
     getDiffAgainstMaster(5, 1).then(() => {
@@ -139,19 +157,25 @@ describe('getDiffAgainstMaster', () => {
   test('Should throw error: SUBMITTING_PLUS_TWO_FILES', () => {
     expect.assertions(1)
 
-    return expect(getDiffAgainstMaster(2, 1)).rejects.toThrow(SUBMITTING_PLUS_TWO_FILES)
+    return expect(getDiffAgainstMaster(2, 1)).rejects.toThrow(
+      SUBMITTING_PLUS_TWO_FILES
+    )
   })
 
   test('Should throw error: INVALID_CHALLENGE_FILE for no challenge files', () => {
     expect.assertions(1)
 
-    return expect(getDiffAgainstMaster(2, 1)).rejects.toThrow(INVALID_CHALLENGE_FILE)
+    return expect(getDiffAgainstMaster(2, 1)).rejects.toThrow(
+      INVALID_CHALLENGE_FILE
+    )
   })
 
   test('Should throw error: SUBMITTING_PLUS_TWO_FILES for submitting +2 challenges', () => {
     expect.assertions(1)
 
-    return expect(getDiffAgainstMaster(2, 1)).rejects.toThrow(SUBMITTING_PLUS_TWO_FILES)
+    return expect(getDiffAgainstMaster(2, 1)).rejects.toThrow(
+      SUBMITTING_PLUS_TWO_FILES
+    )
   })
 
   test('Should throw error: INVALID_SECOND_FILE', () => {
@@ -167,8 +191,8 @@ describe('getDiffAgainstMaster', () => {
     expect.assertions(1)
 
     return expect(getDiffAgainstMaster(2, 1)).resolves.toStrictEqual({
-      db: "\njs0/1.js\njs0/1.test.js",
-      display: "\njs0/1.js\njs0/1.test.js",
+      db: '\njs0/1.js\njs0/1.test.js',
+      display: '\njs0/1.js\njs0/1.test.js',
     })
   })
 
@@ -184,15 +208,34 @@ describe('getDiffAgainstMaster', () => {
   test('Should throw error: INVALID_CHALLENGE_FILE on wrong file', () => {
     expect.assertions(1)
 
-    return expect(getDiffAgainstMaster(2, 1)).rejects.toThrow(INVALID_CHALLENGE_FILE)
+    return expect(getDiffAgainstMaster(2, 1)).rejects.toThrow(
+      INVALID_CHALLENGE_FILE
+    )
   })
 
   test('Should not throw error: INVALID_CHALLENGE_FILE on wrong file', () => {
     expect.assertions(1)
 
     return expect(getDiffAgainstMaster(2, 1)).resolves.toStrictEqual({
-      db: "\njs0/1.js",
-      display: "\njs0/1.js",
+      db: '\njs0/1.js',
+      display: '\njs0/1.js',
     })
+  })
+
+  test('Should submit if html file and lesson is JS3', () => {
+    expect.assertions(1)
+
+    return expect(getDiffAgainstMaster(3, 10)).resolves.toStrictEqual({
+      db: '\njs3/1.html',
+      display: '\njs3/1.html',
+    })
+  })
+
+  test('Should continue if not valid html file', () => {
+    expect.assertions(1)
+
+    return expect(getDiffAgainstMaster(3, 10)).rejects.toThrow(
+      INVALID_CHALLENGE_FILE
+    )
   })
 })

--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -45,14 +45,16 @@ const predictValidFile = (matchWith: string | RegExp) => (e: string) =>
 
 const validateFiles = (
   changedFilesString: string,
-  lessonOrder: number,
+  lessonOrder: string,
   selectedChallengeOrder: string
 ) => {
   // 3 is js3 or Objects
-  if (lessonOrder > 3) return
+  if (+lessonOrder > 3) return
 
   const fileNameRegex = /(^\d+).js/g // Matches 1.js 2.js 3.js ...etc
+  const fileNameWithHtmlRegex = /(.+).html/g // Matches *.html
   const predictCorrectFileName = predictValidFile(fileNameRegex)
+  const predictCorrectFileNameWithHtml = predictValidFile(fileNameWithHtmlRegex)
 
   const changedFilesArray = changedFilesString.trim().split('\n')
 
@@ -61,6 +63,12 @@ const validateFiles = (
     const [challengeFile] = changedFilesArray
     const isFileValid = predictCorrectFileName(challengeFile)
     const changedFileOrder = challengeFile.split('.')[0].split('/')[1]
+
+    if (+lessonOrder === 3) {
+      const validHtmlFile = predictCorrectFileNameWithHtml(challengeFile)
+
+      if (validHtmlFile) return
+    }
 
     if (!isFileValid) throw new Error(INVALID_CHALLENGE_FILE)
 
@@ -103,7 +111,7 @@ const validateFiles = (
 }
 
 export const getDiffAgainstMaster = async (
-  lessonOrder: number,
+  lessonOrder: string,
   challengeOrder: number
 ): Promise<DiffObject> => {
   const { current } = await git.branch()

--- a/src/util/prompt.ts
+++ b/src/util/prompt.ts
@@ -42,7 +42,7 @@ export const getOptionDisplayStr: GetOptionDisplayStr = (array) => {
 export const askForChallenges: AskForChallenges = async (lessons) => {
   const lessonsByOrder = getMapFromOptions(lessons)
   displayBoxUI(getOptionDisplayStr(lessons).trimEnd())
-  const { lessonOrder }: { lessonOrder: number } = await prompt([
+  const { lessonOrder }: { lessonOrder: string } = await prompt([
     {
       type: 'input',
       name: 'lessonOrder',


### PR DESCRIPTION
Closes #62 

### Description

Students should be able to submit an HTML file for the 10th challenge. Currently, when they try to submit, they get:

```
✖ A valid challenge file could not be found. Make sure the file is not renamed and it has the following format: 1.js, 2.js, 3.js, ...etc
```

### Fix

Add a condition to determine if the user is submitting for JS3 and whether the files have `.js` or `.html` extensions.