### PR TITLE
fix: Should allow submitting HTML and JS for JS3

### DIFF
--- a/src/util/git.test.js
+++ b/src/util/git.test.js
@@ -31,6 +31,7 @@ jest.mock('simple-git/promise', () =>
         .mockResolvedValueOnce({ current: 'notMaster' })
         .mockResolvedValueOnce({ current: 'notMaster' })
         .mockResolvedValueOnce({ current: 'notMaster' })
+        .mockResolvedValueOnce({ current: 'notMaster' })
         .mockResolvedValueOnce({ current: 'notMaster' }),
 
       diff: jest
@@ -79,8 +80,10 @@ jest.mock('simple-git/promise', () =>
         .mockResolvedValueOnce('\njs3/1.html')
         // Should continue if not valid html file
         .mockResolvedValueOnce('\njs3/1.mdx')
-        .mockResolvedValueOnce('\njs3/1.mdx')
-        .mockResolvedValueOnce('\njs3/1.mdx'),
+        // Should submit with 2nd file as html for js3
+        .mockResolvedValueOnce('\njs3/10.js\njs3/10.html')
+        .mockResolvedValueOnce('\njs3/10.js\njs3/10.html')
+        .mockResolvedValueOnce('\njs3/10.js\njs3/10.html'),
 
       raw: jest
         .fn()
@@ -96,6 +99,7 @@ jest.mock('simple-git/promise', () =>
         7abfefd HEAD@{1}: checkout: moving from branch2 to master
         `
         )
+        .mockResolvedValueOnce(``)
         .mockResolvedValueOnce(``)
         .mockResolvedValueOnce(``)
         .mockResolvedValueOnce(``)
@@ -237,5 +241,14 @@ describe('getDiffAgainstMaster', () => {
     return expect(getDiffAgainstMaster(3, 10)).rejects.toThrow(
       INVALID_CHALLENGE_FILE
     )
+  })
+
+  test('Should submit with 2nd file as html for js3', () => {
+    expect.assertions(1)
+
+    return expect(getDiffAgainstMaster(3, 10)).resolves.toStrictEqual({
+      db: '\njs3/10.js\njs3/10.html',
+      display: '\njs3/10.js\njs3/10.html',
+    })
   })
 })

--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -103,6 +103,15 @@ const validateFiles = (
 
   // If 2nd file is not a test file
   if (!testFile) {
+    const is2ndFileHtml = changedFilesArray.find((e) =>
+      predictCorrectFileNameWithHtml(e)
+    )
+
+    // If lesson is JS3 and 2nd file is HTML
+    if (+lessonOrder === 3 && is2ndFileHtml) {
+      return
+    }
+
     const invalidFile = changedFilesArray.find(
       (e) => !predictCorrectFileName(e)
     )


### PR DESCRIPTION
Closes #65 

### Description

When a student tries to submit an HTML and JS file for JS3 10th challenge, it'll throw an error saying the HTML file is invalid because it only allows submitting test file that end with `*.test.js` as the second file.

### Fix

If the lesson the user submitting to is JS3, it'll check if the 2nd file is an HTML, if it's, allow submitting the files.

### Testing

1. Create `js3/test.html`
2. Modify `js3/1.js`
3. Add & Commit the files
4. Submit with `npx ts-node c0d3-cli/src/cli.ts submit  --debug`
5. Notice that it shouldn't throw an error