### PR TITLE
Ignore removed files in the diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c0d3",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Command Line Interface (CLI) for c0d3.com",
   "license": "MIT",
   "homepage": "https://c0d3.com",

--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -149,7 +149,12 @@ export const getDiffAgainstMaster = async (
   validateFiles(changedFilesString, lessonOrder, challengeOrder.toString())
 
   const [display, db] = await Promise.all([
-    git.diff([`--color`, `master..${current}`, ...ignoreFileOptions]),
+    git.diff([
+      `--color`,
+      `master..${current}`,
+      '--diff-filter=d',
+      ...ignoreFileOptions,
+    ]),
     git.diff([`master..${current}`, '--diff-filter=d', ...ignoreFileOptions]),
   ])
 

--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -134,6 +134,7 @@ export const getDiffAgainstMaster = async (
 
   const changedFilesString = await git.diff([
     `master..${current}`,
+    '--diff-filter=d',
     '--name-only',
     ...ignoreFileOptions,
   ])
@@ -149,7 +150,7 @@ export const getDiffAgainstMaster = async (
 
   const [display, db] = await Promise.all([
     git.diff([`--color`, `master..${current}`, ...ignoreFileOptions]),
-    git.diff([`master..${current}`, ...ignoreFileOptions]),
+    git.diff([`master..${current}`, '--diff-filter=d', ...ignoreFileOptions]),
   ])
 
   return {


### PR DESCRIPTION
This PR fixes and closes these issues #78 https://github.com/garageScript/c0d3-app/issues/3066
This PR adds a filter to the diff command to ignore deleted files from showing in the diff.